### PR TITLE
Removed the dependency for python2.6.  Python2 should suffice.

### DIFF
--- a/generate_updateinfo.py
+++ b/generate_updateinfo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python26
+#!/usr/bin/env python2
 #    Copyright (C) 2013  Kristian K. [http://vmfarms.com] [kris@vmfarms.com]
 #
 #    This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
EL7 is shipping python2.7.  If there isn't a direct dependency on 2.6, specifying python2 should work.
