### PR TITLE
Make format command backwards compatable with Python 2.6.6

### DIFF
--- a/generate_updateinfo.py
+++ b/generate_updateinfo.py
@@ -37,7 +37,7 @@ adv_types = {
 }
 
 from optparse import OptionParser
-parser = OptionParser(usage= "usage: {} [options] <path to errata.xml>".format(os.path.basename(__file__)))
+parser = OptionParser(usage= "usage: {0} [options] <path to errata.xml>".format(os.path.basename(__file__)))
 
 parser.add_option("-r", "--release", dest="release", default=[],
                   type=str, action='append', help="What releases would you like to track")


### PR DESCRIPTION
The most recent merge breaks the ability to run on python 2.6.6 (CentOS 6) see http://stackoverflow.com/questions/21034954/valueerror-zero-length-field-name-in-format-in-python2-6-6

By adding the number back it works on 2.6.6 and 2.7.5 (CentOS 7)