### PR TITLE
Fixing problem where an update with a single package would be improperly processed.

### DIFF
--- a/generate_updateinfo.py
+++ b/generate_updateinfo.py
@@ -281,6 +281,11 @@ def build_updateinfo(src):
             # If we can't pull the release, then we infer it from the package names
             p_release = release
             packages = []
+
+            if type(sec_dict.packages) is not list:
+              pkgs = [ sec_dict.packages ]
+              sec_dict.packages = pkgs
+
             for pkg in sec_dict.packages:
                 package = None
                 # Parse the package name


### PR DESCRIPTION
sec_dict.packages is most often a list but in the case of a single package it is a string. This caused the for loop to iterate over the letters in the string instead of the list of packages.